### PR TITLE
Fix shebang in setup script

### DIFF
--- a/setup_googletest.sh
+++ b/setup_googletest.sh
@@ -1,4 +1,4 @@
-#/bin/sh
+#!/bin/sh
 
 # shell option
 set -eu


### PR DESCRIPTION
## Summary
- fix the shebang line in `setup_googletest.sh`

## Testing
- `./setup_googletest.sh` *(fails: CONNECT tunnel failed, response 403)*
- `cmake .`
- `make` *(fails: missing gtest headers)*

------
https://chatgpt.com/codex/tasks/task_e_6849870b2b28832db3085354791493d3