### PR TITLE
Fix hashtable hash argument order

### DIFF
--- a/src/hashtable.cpp
+++ b/src/hashtable.cpp
@@ -58,7 +58,8 @@ void set_node(Node *n, Data x, Node *next)
  */
 bool insert_node(Hash *h, Data x)
 {
-    int key = hash(h->size, x.no);
+    // calculate hash value from key "x.no" and hash table size "h->size"
+    int key = hash(x.no, h->size);
     Node *p = h->table[key];
     Node *temp;
 


### PR DESCRIPTION
## Summary
- correct hash argument order in `insert_node`

## Testing
- `cmake . && make` *(fails: gtest headers not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849858aaa6c832db04464511f445bab