### PR TITLE
Add stock price C example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,12 +5,14 @@ set(CMAKE_CXX_STANDARD 17)
 
 # Add include directories
 include_directories(${PROJECT_SOURCE_DIR}/vendor/googletest/include)
+include_directories(${PROJECT_SOURCE_DIR}/src)
 
 # Define linking static libraries
 set(static_libraries
         ${PROJECT_SOURCE_DIR}/vendor/googletest/lib/libgtest.a
         ${PROJECT_SOURCE_DIR}/vendor/googletest/lib/libgtest_main.a
         -lpthread
+        -lcurl
         )
 
 # Define source files
@@ -18,11 +20,15 @@ set(cpplang_src
         src/array.cpp
         src/hashtable.cpp
         src/math.cpp
+        src/stock.c
         test/array_unittest.cpp
         test/hashtable_unittest.cpp
         test/math_unittest.cpp
+        test/stock_unittest.cpp
         main.cpp
         )
+
+set_source_files_properties(src/stock.c PROPERTIES LANGUAGE C)
 
 add_executable(cpplang_library ${cpplang_src})
 target_link_libraries(cpplang_library ${static_libraries})

--- a/setup_googletest.sh
+++ b/setup_googletest.sh
@@ -4,7 +4,7 @@
 set -eu
 
 # Variables
-PACKAGE=release-1.10.0
+PACKAGE=release-1.12.1
 PACKAGE_FILE=${PACKAGE}.tar.gz
 TEMP_FOLDER=googletest-${PACKAGE}
 

--- a/src/stock.c
+++ b/src/stock.c
@@ -1,0 +1,65 @@
+#include "stock.h"
+#include <curl/curl.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+struct string_buffer {
+    char *data;
+    size_t length;
+};
+
+static void init_buffer(struct string_buffer *sb) {
+    sb->length = 0;
+    sb->data = malloc(1);
+    if (sb->data)
+        sb->data[0] = '\0';
+}
+
+static size_t write_cb(void *ptr, size_t size, size_t nmemb, void *userdata) {
+    size_t total = size * nmemb;
+    struct string_buffer *sb = userdata;
+    char *new_data = realloc(sb->data, sb->length + total + 1);
+    if (!new_data)
+        return 0;
+    sb->data = new_data;
+    memcpy(sb->data + sb->length, ptr, total);
+    sb->length += total;
+    sb->data[sb->length] = '\0';
+    return total;
+}
+
+double parse_stock_price(const char *json) {
+    const char *key = "\"regularMarketPrice\":";
+    const char *pos = strstr(json, key);
+    if (!pos)
+        return -1.0;
+    pos += strlen(key);
+    return strtod(pos, NULL);
+}
+
+double fetch_stock_price(const char *symbol) {
+    CURL *curl = curl_easy_init();
+    if (!curl)
+        return -1.0;
+
+    char url[256];
+    snprintf(url, sizeof(url),
+             "https://query1.finance.yahoo.com/v7/finance/quote?symbols=%s", symbol);
+
+    struct string_buffer sb;
+    init_buffer(&sb);
+
+    curl_easy_setopt(curl, CURLOPT_URL, url);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_cb);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &sb);
+    CURLcode res = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
+
+    double price = -1.0;
+    if (res == CURLE_OK)
+        price = parse_stock_price(sb.data);
+
+    free(sb.data);
+    return price;
+}

--- a/src/stock.h
+++ b/src/stock.h
@@ -1,0 +1,15 @@
+#ifndef STOCK_H
+#define STOCK_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+double fetch_stock_price(const char *symbol);
+double parse_stock_price(const char *json);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // STOCK_H

--- a/test/stock_unittest.cpp
+++ b/test/stock_unittest.cpp
@@ -1,0 +1,11 @@
+#include "gtest/gtest.h"
+extern "C" {
+#include "stock.h"
+}
+
+TEST(StockTest, ParsePrice) {
+    const char *json = "{\"regularMarketPrice\": 123.45}";
+    double price = parse_stock_price(json);
+    EXPECT_NEAR(price, 123.45, 1e-6);
+}
+


### PR DESCRIPTION
## Summary
- add script update to use googletest release-1.12.1
- add simple C module `stock.c`/`stock.h` to fetch stock prices
- link libcurl and include new stock tests in build
- add unit test for JSON price parsing

## Testing
- `./setup_googletest.sh`
- `cmake .`
- `make -j$(nproc)`
- `./cpplang_library`

------
https://chatgpt.com/codex/tasks/task_e_68498eda2644832da10c11115701fa28